### PR TITLE
Add new status to `outbox.Record` 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test
 test:
-	go test -race -cover -bench=. ./...
+	go test -fullpath -race -cover -bench=. ./...
 
 lint-local:
 	golangci-lint run

--- a/inbox/dto.go
+++ b/inbox/dto.go
@@ -1,16 +1,20 @@
 package inbox
 
 import (
+	"sort"
+	"time"
+
 	"github.com/google/uuid"
 )
 
 type dtoRecord struct {
-	ID         string `db:"id"`
-	Status     string `db:"status"`
-	EventType  string `db:"event_type"`
-	HandlerKey string `db:"handler_key"`
-	Payload    []byte `db:"payload"`
-	Attempt    int    `db:"attempt"`
+	ID         string    `db:"id"`
+	Status     string    `db:"status"`
+	EventType  string    `db:"event_type"`
+	HandlerKey string    `db:"handler_key"`
+	Payload    []byte    `db:"payload"`
+	Attempt    int       `db:"attempt"`
+	CreatedAt  time.Time `db:"created_at"`
 }
 
 func newDtoRecord(id, status, eventType, handlerKey string, payload []byte, attempt int) *dtoRecord {
@@ -34,6 +38,13 @@ func makeRecord(dto *dtoRecord) (*Record, error) {
 }
 
 func makeRecords(dtos []*dtoRecord) ([]*Record, error) {
+	sort.Slice(dtos, func(i, j int) bool {
+		t1 := dtos[i].CreatedAt
+		t2 := dtos[j].CreatedAt
+
+		return t1.Before(t2)
+	})
+
 	result := make([]*Record, len(dtos))
 
 	for i := 0; i < len(dtos); i++ {

--- a/inbox/dto_test.go
+++ b/inbox/dto_test.go
@@ -1,0 +1,50 @@
+package inbox_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Melenium2/go-iobox/inbox"
+)
+
+func TestMakeRecords_Should_sorts_dtos_by_created_at_in_asc_order(t *testing.T) {
+	dtos := []*inbox.DTORecord{
+		{
+			ID:         inbox.ID2().String(),
+			Status:     "progress",
+			EventType:  "1",
+			HandlerKey: "2",
+			Payload:    []byte("{}"),
+			CreatedAt:  time.Date(2000, 1, 1, 1, 15, 0, 0, time.UTC),
+		},
+		{
+			ID:         inbox.ID1().String(),
+			Status:     "progress",
+			EventType:  "1",
+			HandlerKey: "1",
+			Payload:    []byte("{}"),
+			CreatedAt:  time.Date(2000, 1, 1, 1, 13, 0, 0, time.UTC),
+		},
+		{
+			ID:         inbox.ID3().String(),
+			Status:     "",
+			EventType:  "2",
+			HandlerKey: "1",
+			Payload:    []byte("{}"),
+			CreatedAt:  time.Date(2000, 1, 1, 1, 17, 0, 0, time.UTC),
+		},
+	}
+
+	expected := []*inbox.Record{
+		inbox.Record1(),
+		inbox.Record2(),
+		inbox.Record3(),
+	}
+
+	res, err := inbox.MakeRecords(dtos)
+	require.NoError(t, err)
+	assert.Equal(t, expected, res)
+}

--- a/inbox/export_test.go
+++ b/inbox/export_test.go
@@ -124,3 +124,9 @@ func (r *Record) Deadline() time.Time {
 func (i *Inbox) FailOrDead(record *Record, err error) *Record {
 	return i.failOrDead(record, err)
 }
+
+type DTORecord = dtoRecord
+
+func MakeRecords(dtos []*DTORecord) ([]*Record, error) {
+	return makeRecords(dtos)
+}

--- a/inbox/migrations/1685209074_init_schema.up.sql
+++ b/inbox/migrations/1685209074_init_schema.up.sql
@@ -10,4 +10,3 @@ create table if not exists __inbox_table
 );
 
 create unique index if not exists __inbox_uniq_id_handler_key_idx on __inbox_table (id, handler_key);
-

--- a/inbox/storage.go
+++ b/inbox/storage.go
@@ -24,7 +24,7 @@ func (s *defaultStorage) InitInboxTable(ctx context.Context) error {
 	m := migration.New()
 
 	if err := m.SetupFS(ctx, s.conn, migrations.FS, "inbox_schema"); err != nil {
-		return fmt.Errorf("error while migrations, %w", err)
+		return fmt.Errorf("failed to setup inbox migrations, %w", err)
 	}
 
 	err := m.Up()
@@ -34,7 +34,7 @@ func (s *defaultStorage) InitInboxTable(ctx context.Context) error {
 
 	_ = m.Down()
 
-	return err
+	return fmt.Errorf("failed to run migrations, %w", err)
 }
 
 func (s *defaultStorage) Fetch(ctx context.Context, fetchTime time.Time) ([]*Record, error) {

--- a/outbox/client.go
+++ b/outbox/client.go
@@ -2,12 +2,17 @@ package outbox
 
 import (
 	"context"
+	"database/sql"
 )
+
+type Execer interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}
 
 // Client provides possibility to set outbox record to the outbox table.
 // Insertion must be in the same transaction as the produced action.
 type Client interface {
-	WriteOutbox(context.Context, SQLConn, *Record) error
+	WriteOutbox(context.Context, Execer, *Record) error
 }
 
 type client struct {
@@ -20,6 +25,6 @@ func newClient(storage *defaultStorage) *client {
 	}
 }
 
-func (c *client) WriteOutbox(ctx context.Context, tx SQLConn, record *Record) error {
+func (c *client) WriteOutbox(ctx context.Context, tx Execer, record *Record) error {
 	return c.storage.Insert(ctx, tx, record)
 }

--- a/outbox/config.go
+++ b/outbox/config.go
@@ -11,6 +11,8 @@ const (
 	//
 	// Default: 5 * time.Second.
 	DefaultIterationRate = 5 * time.Second
+	// TODO doc and option.
+	DefaultTimeout = 1 * time.Second
 	// DebugMode enables additional logs for debug outbox process.
 	// Now, this option do nothing.
 	//
@@ -22,6 +24,7 @@ var DefaultLogger = log.Default()
 
 type config struct {
 	iterationRate time.Duration
+	timeout       time.Duration
 	logger        Logger
 	debugMode     bool
 }
@@ -29,6 +32,7 @@ type config struct {
 func defaultConfig() config {
 	return config{
 		iterationRate: DefaultIterationRate,
+		timeout:       DefaultTimeout,
 		logger:        DefaultLogger,
 		debugMode:     DebugMode,
 	}

--- a/outbox/config.go
+++ b/outbox/config.go
@@ -11,8 +11,12 @@ const (
 	//
 	// Default: 5 * time.Second.
 	DefaultIterationRate = 5 * time.Second
-	// TODO doc and option.
-	DefaultPublishTimeout = 1 * time.Second
+	// DefaultPublishTimeout is the timeout after which the publication
+	// of the current event is canceled. The current event marked as 'not yet published', and
+	// processing continues.
+	//
+	// Default: 2 * time.Second.
+	DefaultPublishTimeout = 2 * time.Second
 	// DebugMode enables additional logs for debug outbox process.
 	// Now, this option do nothing.
 	//
@@ -55,6 +59,15 @@ func WithIterationRate(dur time.Duration) Option {
 func WithLogger(logger Logger) Option {
 	return func(c config) config {
 		c.logger = logger
+
+		return c
+	}
+}
+
+// WithPublishTimeout sets a custom timeout for publishing next event.
+func WithPublishTimeout(dur time.Duration) Option {
+	return func(c config) config {
+		c.timeout = dur
 
 		return c
 	}

--- a/outbox/config.go
+++ b/outbox/config.go
@@ -12,7 +12,7 @@ const (
 	// Default: 5 * time.Second.
 	DefaultIterationRate = 5 * time.Second
 	// TODO doc and option.
-	DefaultTimeout = 1 * time.Second
+	DefaultPublishTimeout = 1 * time.Second
 	// DebugMode enables additional logs for debug outbox process.
 	// Now, this option do nothing.
 	//
@@ -32,7 +32,7 @@ type config struct {
 func defaultConfig() config {
 	return config{
 		iterationRate: DefaultIterationRate,
-		timeout:       DefaultTimeout,
+		timeout:       DefaultPublishTimeout,
 		logger:        DefaultLogger,
 		debugMode:     DebugMode,
 	}

--- a/outbox/dto.go
+++ b/outbox/dto.go
@@ -1,22 +1,27 @@
 package outbox
 
 import (
+	"sort"
+	"time"
+
 	"github.com/google/uuid"
 )
 
 type dtoRecord struct {
-	ID        string `db:"id"`
-	Status    string `db:"status"`
-	EventType string `db:"event_type"`
-	Payload   []byte `db:"payload"`
+	ID        string    `db:"id"`
+	Status    string    `db:"status"`
+	EventType string    `db:"event_type"`
+	Payload   []byte    `db:"payload"`
+	CreatedAt time.Time `db:"created_at"`
 }
 
-func newDtoRecord(id, status, eventType string, payload []byte) *dtoRecord {
+func newDtoRecord(id, status, eventType string, payload []byte, createdAt time.Time) *dtoRecord {
 	return &dtoRecord{
 		ID:        id,
 		Status:    status,
 		EventType: eventType,
 		Payload:   payload,
+		CreatedAt: createdAt,
 	}
 }
 
@@ -40,6 +45,13 @@ func makeRecord(dto *dtoRecord) (*Record, error) {
 }
 
 func makeRecords(dtos []*dtoRecord) ([]*Record, error) {
+	sort.Slice(dtos, func(i, j int) bool {
+		t1 := dtos[i].CreatedAt
+		t2 := dtos[j].CreatedAt
+
+		return t1.Before(t2)
+	})
+
 	result := make([]*Record, len(dtos))
 
 	for i := 0; i < len(dtos); i++ {

--- a/outbox/dto_test.go
+++ b/outbox/dto_test.go
@@ -1,0 +1,47 @@
+package outbox_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Melenium2/go-iobox/outbox"
+)
+
+func TestMakeRecords_Should_sorts_dtos_by_created_at_in_asc_order(t *testing.T) {
+	dtos := []*outbox.DTORecord{
+		{
+			ID:        outbox.ID2().String(),
+			Status:    "progress",
+			EventType: "topic1",
+			Payload:   []byte("{}"),
+			CreatedAt: time.Date(2000, 1, 1, 1, 15, 0, 0, time.UTC),
+		},
+		{
+			ID:        outbox.ID1().String(),
+			Status:    "progress",
+			EventType: "topic1",
+			Payload:   []byte("{}"),
+			CreatedAt: time.Date(2000, 1, 1, 1, 13, 0, 0, time.UTC),
+		},
+		{
+			ID:        outbox.ID3().String(),
+			Status:    "done",
+			EventType: "topic1",
+			Payload:   []byte("{}"),
+			CreatedAt: time.Date(2000, 1, 1, 1, 17, 0, 0, time.UTC),
+		},
+	}
+
+	expected := []*outbox.Record{
+		outbox.Record1(),
+		outbox.Record2(),
+		outbox.Record3(),
+	}
+
+	res, err := outbox.MakeRecrods(dtos)
+	require.NoError(t, err)
+	assert.Equal(t, expected, res)
+}

--- a/outbox/export_test.go
+++ b/outbox/export_test.go
@@ -2,6 +2,7 @@ package outbox
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/google/uuid"
 )
@@ -46,7 +47,7 @@ func Record3() *Record {
 	return newFullRecord(id3, Done, "topic1", &payload)
 }
 
-func NewStorage(conn SQLConn) *defaultStorage {
+func NewStorage(conn *sql.DB) *defaultStorage {
 	return newStorage(conn)
 }
 

--- a/outbox/export_test.go
+++ b/outbox/export_test.go
@@ -54,3 +54,9 @@ func NewStorage(conn *sql.DB) *defaultStorage {
 func (o *Outbox) Iteration() error {
 	return o.iteration(context.Background())
 }
+
+type DTORecord = dtoRecord
+
+func MakeRecrods(dtos []*DTORecord) ([]*Record, error) {
+	return makeRecords(dtos)
+}

--- a/outbox/migrations/1693035377_init_outbox_table.down.sql
+++ b/outbox/migrations/1693035377_init_outbox_table.down.sql
@@ -1,0 +1,1 @@
+drop table if exists __outbox_table;

--- a/outbox/migrations/1693035377_init_outbox_table.up.sql
+++ b/outbox/migrations/1693035377_init_outbox_table.up.sql
@@ -1,0 +1,8 @@
+create table if not exists __outbox_table (
+    id varchar(36) not null primary key,
+    status varchar(12),
+    event_type varchar(255) not null,
+    payload jsonb not null,
+    created_at timestamp not null default (now() at time zone 'utc'),
+    updated_at timestamp not null default (now() at time zone 'utc')
+);

--- a/outbox/migrations/pkg.go
+++ b/outbox/migrations/pkg.go
@@ -1,0 +1,6 @@
+package migrations
+
+import "embed"
+
+//go:embed *.sql
+var FS embed.FS

--- a/outbox/outbox.go
+++ b/outbox/outbox.go
@@ -101,13 +101,13 @@ func (o *Outbox) iteration(ctx context.Context) error {
 		}
 
 		if err := o.publish(ctx, record.eventType, payload); err != nil {
-			// TODO doc.
+			// If we can not publish the event during a connection issue
+			// or whatever, we set the current record status to Null.
+			// This means that the current record has not yet been published.
 			record.Null()
 
 			o.logger.Print(err.Error())
 		}
-
-		o.logger.Print("new record iteration")
 	}
 
 	if err := o.updateStatus(ctx, records); err != nil {

--- a/outbox/outbox.go
+++ b/outbox/outbox.go
@@ -147,8 +147,6 @@ func (o *Outbox) updateStatus(ctx context.Context, records []*Record) error {
 		}
 	}
 
-	o.logger.Printf("null = %d, success = %d, fail = %d", len(null), len(success), len(fail))
-
 	if err := o.storage.Update(ctx, success); err != nil {
 		return err
 	}

--- a/outbox/outbox.go
+++ b/outbox/outbox.go
@@ -118,7 +118,7 @@ func (o *Outbox) iteration(ctx context.Context) error {
 }
 
 func (o *Outbox) publish(ctx context.Context, eventType string, payload []byte) error {
-	ctx, cancel := context.WithTimeout(context.Background(), o.config.timeout)
+	ctx, cancel := context.WithTimeout(ctx, o.config.timeout)
 	defer cancel()
 
 	err := o.broker.Publish(ctx, eventType, payload)

--- a/outbox/record.go
+++ b/outbox/record.go
@@ -17,6 +17,8 @@ const (
 	Failed Status = "failed"
 	// Done means the current Record is successfully processed.
 	Done Status = "done"
+	// Null means the current Record is not processed yet.
+	Null Status = ""
 )
 
 // Record is event that should be processed by outbox worker.
@@ -43,7 +45,12 @@ func NewRecord(id uuid.UUID, eventType string, payload json.Marshaler) *Record {
 	}
 }
 
-func newFullRecord(id uuid.UUID, status Status, eventType string, payload json.Marshaler) *Record {
+func newFullRecord(
+	id uuid.UUID,
+	status Status,
+	eventType string,
+	payload json.Marshaler,
+) *Record {
 	return &Record{
 		id:        id,
 		status:    status,
@@ -62,4 +69,9 @@ func (r *Record) Done() {
 // ignored on first save to the outbox table.
 func (r *Record) Fail() {
 	r.status = Failed
+}
+
+// Null sets Null status to current Record.
+func (r *Record) Null() {
+	r.status = ""
 }

--- a/outbox/storage.go
+++ b/outbox/storage.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"strings"
 	"time"
+
+	"github.com/lib/pq"
 
 	"github.com/Melenium2/go-iobox/migration"
 	"github.com/Melenium2/go-iobox/outbox/migrations"
@@ -67,7 +68,7 @@ func (s *defaultStorage) Update(ctx context.Context, records []*Record) error {
 		sqlStr = "update __outbox_table set " +
 			" 			status = $1, " +
 			"			updated_at = (now() at time zone 'utc') " +
-			" 		where id in ($2);"
+			" 		where id = any ($2);"
 
 		recordsStatus sql.NullString
 	)
@@ -82,7 +83,7 @@ func (s *defaultStorage) Update(ctx context.Context, records []*Record) error {
 		ids[i] = records[i].id.String()
 	}
 
-	_, err := s.conn.ExecContext(ctx, sqlStr, recordsStatus, strings.Join(ids, ", "))
+	_, err := s.conn.ExecContext(ctx, sqlStr, recordsStatus, pq.Array(ids))
 
 	return err
 }

--- a/outbox/storage.go
+++ b/outbox/storage.go
@@ -3,33 +3,39 @@ package outbox
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"strings"
+	"time"
+
+	"github.com/Melenium2/go-iobox/migration"
+	"github.com/Melenium2/go-iobox/outbox/migrations"
 )
 
 type defaultStorage struct {
-	conn SQLConn
+	conn *sql.DB
 }
 
-func newStorage(conn SQLConn) *defaultStorage {
+func newStorage(conn *sql.DB) *defaultStorage {
 	return &defaultStorage{
 		conn: conn,
 	}
 }
 
 func (s *defaultStorage) InitOutboxTable(ctx context.Context) error {
-	sql := "create table if not exists __outbox_table " +
-		" 	(" +
-		" 		id varchar(36) not null primary key," +
-		" 		status varchar(12)," +
-		" 		event_type varchar(255) not null," +
-		" 		payload jsonb not null," +
-		" 		created_at timestamp not null default (now() at time zone 'utc')," +
-		" 		updated_at timestamp not null default (now() at time zone 'utc')" +
-		" 	);"
+	m := migration.New()
 
-	_, err := s.conn.ExecContext(ctx, sql)
+	if err := m.SetupFS(ctx, s.conn, migrations.FS, "outbox_schema"); err != nil {
+		return fmt.Errorf("failed to setup outbox migrations, %w", err)
+	}
 
-	return err
+	err := m.Up()
+	if err == nil {
+		return nil
+	}
+
+	_ = m.Down()
+
+	return fmt.Errorf("failed to run migrations, %w", err)
 }
 
 func (s *defaultStorage) Fetch(ctx context.Context) ([]*Record, error) {
@@ -39,7 +45,7 @@ func (s *defaultStorage) Fetch(ctx context.Context) ([]*Record, error) {
 		" 				status = $1," +
 		" 				updated_at = (now() at time zone 'utc') " +
 		" 		where status is null " +
-		" 		returning id, status, event_type, payload;"
+		" 		returning id, status, event_type, payload, created_at;"
 
 	if err := s.selectRows(ctx, s.conn, &dest, sqlStr, Progress); err != nil {
 		return nil, err
@@ -81,7 +87,7 @@ func (s *defaultStorage) Update(ctx context.Context, records []*Record) error {
 	return err
 }
 
-func (s *defaultStorage) Insert(ctx context.Context, tx SQLConn, record *Record) error {
+func (s *defaultStorage) Insert(ctx context.Context, tx Execer, record *Record) error {
 	sqlStr := "insert into __outbox_table (id, event_type, payload) values ($1, $2, $3) " +
 		" on conflict do nothing;"
 
@@ -95,7 +101,7 @@ func (s *defaultStorage) Insert(ctx context.Context, tx SQLConn, record *Record)
 	return err
 }
 
-func (s *defaultStorage) selectRows(ctx context.Context, conn SQLConn, dest *[]*dtoRecord, sqlStr string, args ...any) error {
+func (s *defaultStorage) selectRows(ctx context.Context, conn *sql.DB, dest *[]*dtoRecord, sqlStr string, args ...any) error {
 	rows, err := conn.QueryContext(ctx, sqlStr, args...)
 	if err != nil {
 		return err
@@ -108,14 +114,15 @@ func (s *defaultStorage) selectRows(ctx context.Context, conn SQLConn, dest *[]*
 		status    sql.NullString
 		eventType string
 		payload   []byte
+		createdAt time.Time
 	)
 	for rows.Next() {
-		err = rows.Scan(&id, &status, &eventType, &payload)
+		err = rows.Scan(&id, &status, &eventType, &payload, &createdAt)
 		if err != nil {
 			return err
 		}
 
-		*dest = append(*dest, newDtoRecord(id, status.String, eventType, payload))
+		*dest = append(*dest, newDtoRecord(id, status.String, eventType, payload, createdAt))
 	}
 
 	return nil

--- a/outbox/storage_test.go
+++ b/outbox/storage_test.go
@@ -116,6 +116,31 @@ func (suite *StorageSuite) TestUpdate_Should_update_provided_records_with_new_st
 	}
 }
 
+func (suite *StorageSuite) TestUpdate_Should_set_null_status_to_record() {
+	initInProgressRows(suite.db)
+
+	ctx := context.Background()
+
+	record1 := outbox.Record1()
+	record1.Null()
+
+	record2 := outbox.Record2()
+	record2.Null()
+
+	err := suite.storage.Update(ctx, []*outbox.Record{record1, record2})
+	suite.Require().NoError(err)
+
+	{
+		var (
+			sqlStr   = "select count(*) from __outbox_table where id in ($1, $2) and status is not null;"
+			expected = 0
+			dest     int
+		)
+		_ = suite.db.QueryRow(sqlStr, outbox.ID1(), outbox.ID2()).Scan(&dest)
+		suite.Assert().Equal(expected, dest)
+	}
+}
+
 func (suite *StorageSuite) TestInsert_Should_insert_new_records_to_table() {
 	initInProgressRows(suite.db)
 


### PR DESCRIPTION
Feat `outbox/inbox`:
- Sorting `outbox/inbox` dto by `created_at` field

Feat `outbox`:
- Added new `PublishTimeout` field to config
- Moved migrations to separated file
- Now, if broker can not publish the message, set status `Null` to `Record`

Refactor:
- Updated error messages

Fix:
- Changed flag in the `go test` command